### PR TITLE
Fix loading of bandwidth parameter.

### DIFF
--- a/LoRa/sx1278.c
+++ b/LoRa/sx1278.c
@@ -1132,7 +1132,7 @@ sx1278_ieee_get_rf_config(struct ieee802154_hw *hw, struct rf_frq *rf)
 		rf->carrier = carrier_frq;
 
 	/* Set the LoRa chip's RF bandwidth. */
-	if (of_property_read_u32(of_node, "rf-bandwidth", &rf->carrier))
+	if (of_property_read_u32(of_node, "rf-bandwidth", &rf->bw))
 		rf->bw = bandwidth;
 
 	/* Set the LoRa chip's min & max RF channel if OF is defined. */


### PR DESCRIPTION
If you set the bandwidth in the device tree it overrides the carrier frequency.

Note also that currently the bandwidth is not set in the LoRa chip.
I added a call to `sx127X_set_lorabw()` in `sx1278_ieee_set_channel()` (not included in this PR).